### PR TITLE
Develop

### DIFF
--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -10,6 +10,14 @@ class SurveyElement(object):
     question_type_dictionary.
     """
 
+    #Supported media types for attaching to questions
+    SUPPORTED_MEDIA = {
+        "image",
+        "audio",
+        "video"
+        }
+    
+
     # the following are important keys for the underlying dict that
     # describes this survey element
     NAME = u"name"
@@ -18,6 +26,7 @@ class SurveyElement(object):
     TYPE = u"type"
     BIND = u"bind"
     CONTROL = u"control"
+    MEDIA = u"media"
     # this node will also have a parent and children, like a tree!
     # these will not be stored in the dict.
     PARENT = u"parent"
@@ -30,6 +39,7 @@ class SurveyElement(object):
         TYPE : u"",
         BIND : {},
         CONTROL : {},
+        MEDIA : u""
         }
 
     def __init__(self, *args, **kwargs):
@@ -149,14 +159,23 @@ class SurveyElement(object):
     def get_translation_keys(self):
         return {
             u"label" : u"%s:label" % self.get_xpath(),
-            u"hint" : u"%s:hint" % self.get_xpath(),
+            u"hint" : u"%s:hint" % self.get_xpath()
             }
-
+      
+    def get_media_keys(self):
+        return {
+            u"media" : u"%s:media" % self.get_xpath()
+            }
+    
+    
     # XML generating functions, these probably need to be moved around.
     def xml_label(self):
         if type(self.get_label())==dict:
             d = self.get_translation_keys()
             return node(u"label", ref="jr:itext('%s')" % d[u"label"])
+        elif type(self.get_media())==dict:
+            d = self.get_media_keys()
+            return node(u"label", ref="jr:itext('%s')" %  d[u"media"])
         else:
             return node(u"label", self.get_label())
 


### PR DESCRIPTION
Hi Andrew,

I finally got around to working on pyxforms. Its a big improvement over xls2xforms and the json middle-step does make a nice clean split between parsing xls and generating xml. Anyway, I've added support for media files (images, audio, and video) in questions. The way to specify them is to make a column with a title of the form "media:image" or "media:audio". This method will attach the specified media file to all translations of a particular question. If you want translations of a media file as well, you title your columns like this: "media:image:English" or "media:audio:Spanish". I tried to keep with your style and paradigm as much as possible. 

I haven't tested whether this works for the select choices. If they are parsed the same it ought to work, but I haven't looked into it. I wanted to see what you thought of the way I do media and their translations now. Let me know if you have any questions about it or want me to send an example xls file. 

Jeff
