### PR TITLE
Test fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: python
 python:
   - "2.7.3"
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install openjdk-6-jre
 install:
   - sudo pip install -r requirements.pip --use-mirrors
 script: nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.6"
 install:
-  - sudo pip install -r requirements.pip --use-mirrors
+  - sudo pip install -r -q requirements.pip --use-mirrors
 script: nosetests
 notifications:
   irc: "irc.freenode.org#modilabs"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "2.7.3"
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install openjdk-6-jre
+script: nosetests
+notifications:
+  irc: "irc.freenode.org#modilabs"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "2.7.3"
+  - "2.6"
 install:
   - sudo pip install -r requirements.pip --use-mirrors
 script: nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install openjdk-6-jre
 install:
-  - pip install -r requirements.pip --user-mirrors
+  - pip install -r requirements.pip --use-mirrors
 script: nosetests
 notifications:
   irc: "irc.freenode.org#modilabs"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.6"
 install:
-  - sudo pip install -r -q requirements.pip --use-mirrors
+  - sudo pip -q install -r requirements.pip --use-mirrors
 script: nosetests
 notifications:
   irc: "irc.freenode.org#modilabs"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
 before_install:
   - sudo apt-get update
   - sudo apt-get install openjdk-6-jre
+install:
+  - pip install -r requirements.pip --user-mirrors
 script: nosetests
 notifications:
   irc: "irc.freenode.org#modilabs"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install openjdk-6-jre
 install:
-  - pip install -r requirements.pip --use-mirrors
+  - sudo pip install -r requirements.pip --use-mirrors
 script: nosetests
 notifications:
   irc: "irc.freenode.org#modilabs"

--- a/pyxform/tests/builder_tests.py
+++ b/pyxform/tests/builder_tests.py
@@ -1,3 +1,5 @@
+from lxml import etree
+from formencode.doctest_xml_compare import xml_compare
 from unittest import TestCase
 from pyxform.builder import SurveyElementBuilder, create_survey_from_xls
 from pyxform.xls2json import print_pyobj_to_json
@@ -15,7 +17,9 @@ class BuilderTests(TestCase):
         path = utils.path_to_text_fixture('widgets.xml')
         survey.to_xml
         with open(path) as f:
-            self.assertEqual(survey.to_xml(), f.read())
+            expected = etree.fromstring(survey.to_xml())
+            result = etree.fromstring(f.read())
+            self.assertTrue(xml_compare(expected, result))
 
     def test_unknown_question_type(self):
         survey = utils.build_survey('unknown_question_type.xls')

--- a/pyxform/tests/xlsform_spec_test.py
+++ b/pyxform/tests/xlsform_spec_test.py
@@ -2,6 +2,8 @@
 Some tests for the new (v0.9) spec is properly implemented.  
 """
 
+from lxml import etree
+from formencode.doctest_xml_compare import xml_compare
 from unittest import TestCase
 import pyxform
 from pyxform import xls2json
@@ -30,7 +32,9 @@ class main_test(TestCase):
         #Compare with the expected output:
         expected_path = utils.path_to_text_fixture("spec_test_expected_output.xml")
         with codecs.open(expected_path, 'rb', encoding="utf-8") as expected_file:
-            self.assertMultiLineEqual(expected_file.read(), survey.to_xml())
+            expected = etree.fromstring(expected_file.read())
+            result = etree.fromstring(survey.to_xml())
+            self.assertTrue(xml_compare(expected, result))
 
 class warnings_test(TestCase):
     """

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,2 +1,4 @@
 nose==1.0.0
 xlrd==0.7.1
+FormEncode==1.2.4
+lxml==2.3.4


### PR DESCRIPTION
this branch started as a fix for failing tests (apparently only for me) having to do with whitespace discrepancies in xml output.  i refactored the tests to pass for me and on travis-cl (which was also added in this branch - http://travis-ci.org/#!/modilabs/pyxform).  this, however, required adding a couple additional libraries.  not sure how people feel about that.  i understand having few dependencies, but i think that when we are dealing with xml files it makes sense to include tools meant to deal with them so we aren't messing around with whitespace and are more concerned with validity and semantic equality.  anyways, this should go without saying, but this pull request should be reviewed/discussed before actually being merged into the core.  please leave comments.
