### PR TITLE
Typo in 'XFormToDict()'.

### DIFF
--- a/pyxform/xform2json.py
+++ b/pyxform/xform2json.py
@@ -167,7 +167,7 @@ class XFormToDict:
             else:
                 self._root = etree.fromstring(root, parser)
             self._dict = ConvertXmlToDict(self._root)
-        elif not isinstance(root, etree.Element):
+        elif not isinstance(root, etree._Element):
             raise TypeError('Expected ElementTree.Element or file path string')
 
     def get_dict(self):


### PR DESCRIPTION
`type(etree.Element)` -> `<type 'builtin_function_or_method'>`

`isinstance(root, etree.Element)` -> `TypeError: isinstance() arg 2 must be a class, type, or tuple of classes and types`
